### PR TITLE
Experiment with Distroless Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,25 +19,13 @@ RUN cargo build --release
 ##################
 # --- runner --- #
 ##################
-FROM docker.io/debian:11-slim
-
-RUN apt-get update && \
-    apt-get dist-upgrade -y && \
-    apt-get install -y tini && \
-    apt-get clean && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt && \
-    useradd -ms /bin/bash dot && \
-    mkdir -p /home/dot/.local/share /data && \
-    ln -s /data /home/dot/.local/share/polkadot && \
-    chown -R dot:dot /home/dot/.local/share && \
-    chown -R dot:dot /data
+FROM gcr.io/distroless/cc
 
 COPY --from=builder /opt/polkadot/target/release/polkadot /usr/local/bin/polkadot
 
-USER dot
-WORKDIR /home/dot
+USER nonroot
+WORKDIR /home/nonroot
 EXPOSE 30333 9933 9944
 VOLUME /data
 
-ENTRYPOINT [ "tini", "--", "/usr/local/bin/polkadot" ]
+ENTRYPOINT [ "/usr/local/bin/polkadot" ]

--- a/README.md
+++ b/README.md
@@ -12,8 +12,15 @@ docker run \
   --net=host \
   --name=polkadot \
   -v /path/to/polkadot:/data \
-  ghcr.io/rblaine95/polkadot ${EXTRA_POLKADOT_ARGS}
+  ghcr.io/rblaine95/polkadot \
+    --base-path=/data ${EXTRA_POLKADOT_ARGS}
 ```
+
+### Distroless nonroot
+This image uses a [Distroless](https://github.com/GoogleContainerTools/distroless) base image and runs as a nonroot user.  
+The nonroot user has a U/GID of `65532`.  
+If you are having IO permission issues then make sure that the persistent volume has permissions set to allow this user Read/Write access.  
+If using [Podman](https://podman.io/) - `podman unshare chown -R 65532:65532 /path/to/polkadot/storage`
 
 ### Where can I download the image?
 I'm using Github Actions to build and publish this image to:


### PR DESCRIPTION
Distroless images are barebones and only have the required dependencies to execute the compiled binary.

The [cc](https://github.com/GoogleContainerTools/distroless/tree/main/cc) image appropriate for languages like Rust.

Benefits include:
* Smaller images
* Smaller attack area due to no unnecessary packages
* Less vulnerability scan noise